### PR TITLE
DeviceSupport files in Xcode11.6beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Xcode DeviceSupport files (iPhoneOS / AppleTVOS / WatchOS)
 
 * iPhoneOS
-  * iOS 8.0 ~ 13.5
+  * iOS 8.0 ~ 13.6
 
 * AppleTVOS
   * tvOS 9.0 ~ 13.4

--- a/iPhoneOS/13.6/DeveloperDiskImage.dmg.signature
+++ b/iPhoneOS/13.6/DeveloperDiskImage.dmg.signature
@@ -1,0 +1,2 @@
+Zð˜s’¬Zr,‡)·“²qƒHÎÿdàOèãKð¬Z¡8x¨E'ùÊG‹<ð€*F’I“m.ôŸ¾ßø¡ss”+¾Ñg©ÜDà%
+3—qV;¾ŒöÃ‰ÂñôÁP"™nm~Ïh1ÿ˜PÛPµM*Ô8¢•©F$?=²DyÓ\Çã-


### PR DESCRIPTION
Add DeviceSupport files in Xcode11.6beta.

- AppleTVOS: nothing
- iPhoneOS: 13.6
- WatchOS: nothing